### PR TITLE
actions/checkoutをv3からv4に更新

### DIFF
--- a/.github/workflows/reusable-ci.yml
+++ b/.github/workflows/reusable-ci.yml
@@ -40,7 +40,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Run Qodo Merge
         uses: qodo-ai/pr-agent@main


### PR DESCRIPTION
## Summary
- `reusable-ci.yml` の `actions/checkout@v3` → `@v4` に更新
- Node.js 20非推奨警告（2026年6月2日以降動作しなくなる）を解消

🤖 Generated with [Claude Code](https://claude.com/claude-code)